### PR TITLE
Allow sub-classes access to Services

### DIFF
--- a/src/Ctct/ConstantContact.php
+++ b/src/Ctct/ConstantContact.php
@@ -42,49 +42,49 @@ class ConstantContact
      * ContactService
      * @var ContactService
      */
-    private $contactService;
+    protected $contactService;
 
     /**
      * CampaignService
      * @var CampaignService
      */
-    private $emailMarketingService;
+    protected $emailMarketingService;
 
     /**
      * ListService
      * @var ListService
      */
-    private $listService;
+    protected $listService;
 
     /**
      * ActivityService
      * @var ActivityService
      */
-    private $activityService;
+    protected $activityService;
 
     /**
      * CampaignTrackingService
      * @var CampaignTrackingService
      */
-    private $campaignTrackingService;
+    protected $campaignTrackingService;
 
     /**
      * ContactTrackingService
      * @var ContactTrackingService
      */
-    private $contactTrackingService;
+    protected $contactTrackingService;
 
     /**
      * CampaignScheduleService
      * @var CampaignScheduleService
      */
-    private $campaignScheduleService;
+    protected $campaignScheduleService;
 
     /**
      * AccountService
      * @var AccountService
      */
-    private $accountService;
+    protected $accountService;
 
     /**
      * Class constructor


### PR DESCRIPTION
Here's my dilemma: I want to use a different REST Client for the services, but because they are private, I would otherwise need to copy all the methods into my subclass in order to override the ConstantContact REST client. This way, I can do the following:

```
class ExampleSubClass extends ConstantContact {
    public function __construct($apiKey) {
        parent::__construct($apiKey);
        $this->setRestClient(new CustomRestClient());
    }

    function setRestClient($restClient) {
        $this->contactService->setRestClient($restClient);
        $this->emailMarketingService->setRestClient($restClient);
        $this->activityService->setRestClient($restClient);
        $this->campaignTrackingService->setRestClient($restClient);
        $this->contactTrackingService->setRestClient($restClient);
        $this->campaignScheduleService->setRestClient($restClient);
        $this->listService->setRestClient($restClient);
        $this->accountService->setRestClient($restClient);
    }
}
```

If there's a better way I don't know about, please let me know. Allowing sub-classes access seems like an easy way to add lots of flexibility without much risk.
