### PR TITLE
Changing case for PHPUnit tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,8 @@
 <phpunit bootstrap="test/bootstrap.php">
   <testsuites>
     <testsuite name="UnitTests">
-      <directory>./test/services</directory>
-      <directory>./test/auth</directory>
+      <directory>test/Services</directory>
+      <directory>test/Auth</directory>
     </testsuite>
   </testsuites>
 </phpunit>


### PR DESCRIPTION
travis-ci was not running unit test due to case sensitivity on directory names in phpunit.xml
