### PR TITLE
Unset empty `spam_count` object key when NULL.

### DIFF
--- a/src/Ctct/Components/Tracking/TrackingSummary.php
+++ b/src/Ctct/Components/Tracking/TrackingSummary.php
@@ -36,6 +36,12 @@ class TrackingSummary extends Component
         $tracking_summary->unsubscribes = parent::getValue($props, "unsubscribes");
         $tracking_summary->bounces = parent::getValue($props, "bounces");
         $tracking_summary->spam_count = parent::getValue($props, "spam_count");
+
+        // Contacts don't have spam_count, only Campaigns
+        if(is_null($tracking_summary->spam_count)) {
+            unset($tracking_summary->spam_count);
+        }
+        
         return $tracking_summary;
     }
 }


### PR DESCRIPTION
`ContactTrackingService::getSummary()` uses `TrackingSummary` as well, but contacts don't have `spam_count`.
