### PR TITLE
prevent run time error if update failed

### DIFF
--- a/src/Ctct/Services/ContactService.php
+++ b/src/Ctct/Services/ContactService.php
@@ -130,6 +130,11 @@ class ContactService extends BaseService
         }
         $url = $this->buildUrl($baseUrl, $params);
         $response = parent::getRestClient()->put($url, parent::getHeaders($accessToken), $contact->toJson());
+
+        if (empty($response->body)) {
+          return null;
+        }
+
         return Contact::create(json_decode($response->body, true));
     }
 }


### PR DESCRIPTION
When trying to change contact's e-mail address to one that already exists, filed under some other contact, the update call returns "" which is decoded to null.
Contact::create() then dies with this error:
Argument 1 passed to Ctct\Components\Contacts\Contact::create() must be an array, null given

It may be that the new address must be unsubscribed, or the new address is unsubscribed and then deleted from a client which doesn't remove it from the system though. I'm not sure about the exact conditions but I'm hitting it all the time during testing.
