### PR TITLE
Make GuzzleHttp\Client Injectable and Shared

### DIFF
--- a/src/Ctct/ConstantContact.php
+++ b/src/Ctct/ConstantContact.php
@@ -10,6 +10,8 @@ use Ctct\Services\ContactTrackingService;
 use Ctct\Services\EmailMarketingService;
 use Ctct\Services\LibraryService;
 use Ctct\Services\ListService;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 
 /**
  * Exposes all implemented Constant Contact API functionality
@@ -78,16 +80,19 @@ class ConstantContact {
      * Class constructor
      * Registers the API key with the ConstantContact class that will be used for all API calls.
      * @param string $apiKey - Constant Contact API Key
+     * @param ClientInterface|null $client - GuzzleHttp Client
      */
-    public function __construct($apiKey) {
-        $this->contactService = new ContactService($apiKey);
-        $this->emailMarketingService = new EmailMarketingService($apiKey);
-        $this->activityService = new ActivityService($apiKey);
-        $this->campaignTrackingService = new CampaignTrackingService($apiKey);
-        $this->contactTrackingService = new ContactTrackingService($apiKey);
-        $this->campaignScheduleService = new CampaignScheduleService($apiKey);
-        $this->listService = new ListService($apiKey);
-        $this->accountService = new AccountService($apiKey);
-        $this->libraryService = new LibraryService($apiKey);
+    public function __construct($apiKey, ClientInterface $client = null) {
+        $client = $client ?: new Client();
+
+        $this->contactService = new ContactService($apiKey, $client);
+        $this->emailMarketingService = new EmailMarketingService($apiKey, $client);
+        $this->activityService = new ActivityService($apiKey, $client);
+        $this->campaignTrackingService = new CampaignTrackingService($apiKey, $client);
+        $this->contactTrackingService = new ContactTrackingService($apiKey, $client);
+        $this->campaignScheduleService = new CampaignScheduleService($apiKey, $client);
+        $this->listService = new ListService($apiKey, $client);
+        $this->accountService = new AccountService($apiKey, $client);
+        $this->libraryService = new LibraryService($apiKey, $client);
     }
 }

--- a/src/Ctct/Services/BaseService.php
+++ b/src/Ctct/Services/BaseService.php
@@ -4,6 +4,7 @@ namespace Ctct\Services;
 use Ctct\Exceptions\CtctException;
 use Ctct\Util\Config;
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Exception\TransferException;
@@ -30,10 +31,11 @@ abstract class BaseService {
     /**
      * Constructor with the option to to supply an alternative rest client to be used
      * @param string $apiKey - Constant Contact API Key
+     * @param ClientInterface|null $client - GuzzleHttp Client
      */
-    public function __construct($apiKey) {
+    public function __construct($apiKey, ClientInterface $client = null) {
         $this->apiKey = $apiKey;
-        $this->client = new Client();
+        $this->client = $client ?: new Client();
     }
 
     protected static function getHeadersForMultipart($accessToken) {

--- a/test/Json/Contacts/error_response.json
+++ b/test/Json/Contacts/error_response.json
@@ -1,0 +1,6 @@
+[
+  {
+    "error_key": "http.status.error",
+    "error_message": "Error message."
+  }
+]

--- a/test/Json/JsonLoader.php
+++ b/test/Json/JsonLoader.php
@@ -54,6 +54,10 @@ class JsonLoader {
         return file_get_contents(__DIR__ . self::CONTACTS_FOLDER . "/get_contacts.json");
     }
 
+    public static function getErrorResponseJson() {
+        return file_get_contents(__DIR__ . self::CONTACTS_FOLDER . "/error_response.json");
+    }
+
     public static function getContactsNoNextJson() {
         return file_get_contents(__DIR__ . self::CONTACTS_FOLDER . "/get_contacts_no_next.json");
     }


### PR DESCRIPTION
- Improve performance and decrease memory usage by sharing a single `GuzzleHttp\Client` across all services.
- Allow a `GuzzleHttp\Client` to be injected during instantiation so that a mock can be used for testing.  The original intention was to allow third parties to use this for testing but it also enables improvements to the internal test suite.
