### PR TITLE
accesstoken.php

### DIFF
--- a/examples/getAccessToken.php
+++ b/examples/getAccessToken.php
@@ -58,7 +58,7 @@ $oauth = new CtctOAuth2(APIKEY, CONSUMER_SECRET, REDIRECT_URI);
             echo '</pre></div>';
             die();
         }
-
+jkjkdikdidkdiekdidkdd
         echo '<span class="label label-success">Access Token Retrieved!</span>';
         echo '<div class="container alert-success"><pre class="success-pre">';
         htmlspecialchars( print_r(  $accessToken ) );


### PR DESCRIPTION
  }

    // If the 'code' query parameter is present in the uri, the code can exchanged for an access token
    if (isset($_GET['code'])) {
        try {
            $accessToken = $oauth->getAccessToken($_GET['code']);
        } catch (OAuth2Exception $ex) {
            echo '<span class="label label-important">OAuth2 Error!</span>';
            echo '<div class="container alert-error"><pre class="failure-pre">';
            echo 'Error: ' . htmlspecialchars( $ex->getMessage() ) . "\n";
            echo "Error Details: \n";
            echo htmlspecialchars( print_r( $ex->getErrors() ) );
            echo '</pre></div>';
            die();